### PR TITLE
remove \r

### DIFF
--- a/lib/sc_hash.rb
+++ b/lib/sc_hash.rb
@@ -1,1 +1,1 @@
-require 'hashie/sc_hash'
+require 'hashie/sc_hash'


### PR DESCRIPTION
in order to get rid of warnings:

```
/Users/peterschroder/.rbenv/versions/2.2.3/bin/ruby -S rspec ./spec/helpers/application_helper_spec.r  1 require 'hashie/sc_hash'
b
/Users/peterschroder/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/snake_case_hash-1.0.3/lib/sc_hash.rb:1: warning: encountered \r in middle of line, treated as a mere space
```
